### PR TITLE
Build on all branches during CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: Packer build
 
 on:
-  push:
-    branches: [main]
+  push: {}
 
 env:
   HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
@@ -11,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment:
-      name: production
+      name: ${{ github.ref_name }}
       url: https://hetzner.cloud/?ref=72AtIaBWO7Uw  # 🤡
     steps:
       - name: Install Butane


### PR DESCRIPTION
Updates the workflows to actually do a "packer build" on branches.

To distinguish between environments, the Git refname is used as the "environment name". This allows selection of the Hetzner Cloud Project via the `HCLOUD_TOKEN` environment variable.